### PR TITLE
Improve IRC server interoperability wrt client register.

### DIFF
--- a/README.org
+++ b/README.org
@@ -56,12 +56,4 @@ Identify with NickServ
 :   :nickserv_password => "secret"
 : )
 
-Register (ping reply) prior to joining or messaging a channel
-(required for some private servers)
 
-: CarrierPigeon.send(
-:   :uri => "irc://nick:password@irc.domain.com:6667/#channel",
-:   :message => "cooooo, coo coo",
-:   :register_first => true,
-:   :join => true
-: )

--- a/lib/carrier-pigeon.rb
+++ b/lib/carrier-pigeon.rb
@@ -22,16 +22,18 @@ class CarrierPigeon
     sendln "PASS #{options[:password]}" if options[:password]
     sendln "NICK #{options[:nick]}"
     sendln "USER #{options[:nick]} 0 * :#{options[:nick]}"
-    sendln options[:nickserv_command] if options[:nickserv_command]
-    if options[:register_first]
-      while line = @socket.gets
-        case line
-          when /^PING :(.+)$/i
-            sendln "PONG :#{$1}"
-            break
-        end
+
+    while line = @socket.gets
+      case line
+      when / 00[1-4] #{Regexp.escape(options[:nick])} /
+        break
+      when /^PING :(.+)$/i
+        sendln "PONG :#{$1}"
       end
     end
+
+    sendln options[:nickserv_command] if options[:nickserv_command]
+
     if options[:join]
       join = "JOIN #{options[:channel]}"
       join += " #{options[:channel_password]}" if options[:channel_password]


### PR DESCRIPTION
Wait for server to reply with 001-004 messages (https://www.alien.net.au/irc/irc2numerics.html)
as a sign for successful register before proceeding. Always reply to PING when
it arrives before initial server response.

Based on github irc service:
https://github.com/github/github-services/blob/master/lib/services/irc.rb#L55-L60
